### PR TITLE
Update dna-router-behaviors.html

### DIFF
--- a/dna-router-behaviors.html
+++ b/dna-router-behaviors.html
@@ -291,10 +291,13 @@ window.addEventListener('WebComponentsReady', function() {
 			if(DNA.ready){
 				var state = utility.getState(this.goto[0])
 				var params = this.goto[1]
+				
+				state.hash = state.route
 
 				for(attr in params){
 					state.hash = state.route.replace(':'+attr, params[attr])
 				}
+				
 				this.setAttribute('href', '#'+state.hash);
 			}
 		},


### PR DESCRIPTION
Fixed a bug for routes without parameters. route.hash was undefined if the route had no parameters
