### PR TITLE
add params property to s-ref links, update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 `ui-router` is an advance Angular's ui-router style all html router provider for Polymer. It has `auth` status which enables user to show different views for same state.
 Inspired by ui-router: https://github.com/angular-ui/ui-router
 
-Install using bower: 
+Install using bower:
 ```script
 bower install dna-router
 ```
@@ -16,7 +16,7 @@ Download starter kit at : <a href='https://github.com/Saquib764/starter-kit-dna-
 
 
 Import all element:
-```script
+```html
 <link rel="import" href="./bower_components/dna-router/dna.html">
 ```
 
@@ -35,7 +35,7 @@ Import all element:
 	By default, `dna-view` converts `element` name into camel case and imports file named so in base directory. This file must contain `home-template` element. Example, above imports `\homeTemplate.html`.
 
 	All params is available in `home-template` polymer properties `params`.
-	
+
 	To import file from different directory:
 	```html
 	<dna-view
@@ -73,16 +73,16 @@ Import all element:
 
 3. Configure `dna-router`:
 	```html
-	<dna-config 
-		id='conf' 
-		home='some state' 
+	<dna-config
+		id='conf'
+		home='some state'
 		auth  // authorise
 		template='\templates'> </dna-config>
 	```
 	By default `home` is state named `home` and `auth` is false.
 
 	To authosrise on fly using javascript:
-	```script
+	```js
 	var conf = document.querySelector('#conf');
 	// Sending login context to views.
 	// Access it using '$state' global variable.
@@ -93,11 +93,25 @@ Import all element:
 	conf.auth = true
 	```
 4. `S-ref` element:
-	```html
-	<a is='s-ref' goto='["users",{"user_id":"56"}]'>To state users</a>
-	```
-	
-	`goto` takes an array as input. First is state name and second item is object with params. Its similar to `ui-router` `s-ref`.
+	- With goto and params property
+		```html
+		<a is='s-ref' goto='["users"]' params='{"user_id":"56"}'>To state users</a>
+		```
+	You can use a Polymer variable in your params :
+		```html
+		<a is='s-ref' goto='["users"]' params='{"user_id":"{{userId}}"}'>To state users</a>
+		```
+
+	- With goto property only *(backward compatibility)*
+
+		`goto` takes an array as input. First is state name and second item is object with params. Its similar to `ui-router` `s-ref`.
+
+		```html
+		<a is='s-ref' goto='["users",{"user_id":"56"}]'>To state users</a>
+		```
+		However you can't use Polymer variables that way.
+
+	Use `$state.params.user_id` to access params.
 
 5. `dna-many-view` element.
 	This element is visible only if any `dna-view` inside this element or any of it's `state` is active.
@@ -110,8 +124,8 @@ Import all element:
 	In above example, many view is visible for states `abc, xyz and home`. For any other state none of its content is visible. `"This Example"` is not visible for some state, i.e `login`.
 
 # Executing a function on page load
-`dna-router` provides a `DNA` object. 
-```script
+`dna-router` provides a `DNA` object.
+```js
 DNA.run = function(){
 	// Do your stuff
 }

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "dna-router",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "authors": [
     "Saquib <saquibvswild@gmail.com>"
   ],

--- a/dna-router-behaviors.html
+++ b/dna-router-behaviors.html
@@ -9,7 +9,7 @@
 	String.prototype.toCamelCase = function() {
 	    return this.replace(/^([A-Z])|[\s-_](\w)/g, function(match, p1, p2, offset) {
 	        if (p2) return p2.toUpperCase();
-	        return p1.toLowerCase();        
+	        return p1.toLowerCase();
 	    });
 	};
 
@@ -492,25 +492,33 @@
 		properties: {
 			goto: {
 				type: Object,
-				observer: '_setHREF'
+			},
+			args: {
+				type: Object,
 			}
 		},
 		attached: function(){
 			srefs.push(this)
 		},
 		go: utility.go,
-		_setHREF: function(){
+		setHREF: function(params) {
 			if(DNA.ready){
-				var state = utility.getState(this.goto[0])
-				var params = this.goto[1]
+				var state = utility.getState(this.goto[0]);
 				var hash = state.route;
-
+				if(params !== undefined && typeof params != 'object')
+					params = JSON.parse(params);
 				for(attr in params){
-					hash = hash.replace(':'+attr, params[attr])
+					hash = hash.replace(':'+attr, params[attr]);
 				}
 				this.setAttribute('href', '#'+hash);
 			}
 		},
+
+		ready: function() {
+			if(undefined === this.goto) console.error('You must set "goto" property')
+			if(undefined !== this.args) this.setHREF(this.args);
+			else this.setHREF(this.goto[1]);
+		}
 	}
 }();
 


### PR DESCRIPTION
This commit add a "params" property to s-ref link elements : it allow usage of {{variable}} in params passed via dna-router.
