### PR TITLE
Remove toCamelCase for accept real name of file

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Import all element:
 	```html
 	<dna-new-state state='home' route='/home'></dna-new-state>
 	<dna-new-state state='user' route='/user/:id/'></dna-new-state>
+	<dna-new-state state='notfound' route='/notfound'></dna-new-state>
 	```
 2. Defining views. You can have multiple views for a single state.
 	```html
@@ -68,6 +69,13 @@ Import all element:
 		with-no-auth
 		element='login-template'
 		else-state='dashboard'></dna-view>
+	```
+
+	Set a not found page
+	```html
+	<dna-view
+		state='notfound'
+		element='notfound-template'></dna-view>
 	```
 
 

--- a/dna-router-behaviors.html
+++ b/dna-router-behaviors.html
@@ -6,12 +6,6 @@
 	var DNA = {
 		ready: false,
 	}
-	String.prototype.toCamelCase = function() {
-	    return this.replace(/^([A-Z])|[\s-_](\w)/g, function(match, p1, p2, offset) {
-	        if (p2) return p2.toUpperCase();
-	        return p1.toLowerCase();
-	    });
-	};
 
 	$state = null;
 
@@ -75,10 +69,12 @@
 					route='/'
 
 				var res = utility._resolveRoute(route);
-				if(res.found)
+				if(res.found){
 					utility.go(res.found, res.param, true)
-				else
-					console.log('wrong url')
+				}else{
+					console.log('Page not found');
+					window.location.hash = "#/notfound"
+				}
 			}
 			else{
 				utility.go(config.home)
@@ -284,7 +280,7 @@
 
 
         	if(element){
-	        	var file = '/'+element.toCamelCase()+'.html';
+	        	var file = '/'+element+'.html';
 	        	template +=file;
 
 	        	if(config.manualLoad){


### PR DESCRIPTION
*and If page not found (wrong url) redirects to / notfound

These two changes were required for use in one of my projects, validate whether it is legal to import by the original filename

esp-login Instead of espLogin for element esp-login